### PR TITLE
Enable SIMD SHA256 batching

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -2,7 +2,11 @@
 
 CC = cc
 NASM = nasm
-CC_FLAGS ?= -O3 -funroll-loops -fomit-frame-pointer -ffast-math -Wall -Wextra -DNO_SIMD
+SIMD ?= 1
+CC_FLAGS ?= -O3 -funroll-loops -fomit-frame-pointer -ffast-math -Wall -Wextra
+ifeq ($(SIMD),0)
+CC_FLAGS += -DNO_SIMD
+endif
 
 ## Optimized build flags
 CFLAGS += -march=native -mavx2 -maes -msha -funroll-loops -O3 -ffast-math -pthread

--- a/lib/addr.c
+++ b/lib/addr.c
@@ -95,8 +95,26 @@ void addr33_batch(h160_t *hashes, const pe *points, size_t count) {
   u8 msg[HASH_BATCH_SIZE][33] = {0}; // sha256 payload
   u32 rs[HASH_BATCH_SIZE][16] = {0}; // sha256 output and rmd160 input
 
-  for (size_t i = 0; i < count; ++i) prepare33(msg[i], points + i);
+  u8 *msg_ptr[HASH_BATCH_SIZE];
+  u8 *dig_ptr[HASH_BATCH_SIZE];
+
+  for (size_t i = 0; i < count; ++i) {
+    prepare33(msg[i], points + i);
+    msg_ptr[i] = msg[i];
+    dig_ptr[i] = (u8 *)rs[i];
+  }
+
+#if defined(NO_SIMD) || RMD_LEN == 1
   for (size_t i = 0; i < count; ++i) sha256_final(rs[i], msg[i], 33);
+#else
+  if (count == 8 && RMD_LEN >= 8) {
+    sha256_8w(msg_ptr, 33, dig_ptr);
+  } else if (count == 4 && RMD_LEN >= 4) {
+    sha256_4w(msg_ptr, 33, dig_ptr);
+  } else {
+    for (size_t i = 0; i < count; ++i) sha256_final(rs[i], msg[i], 33);
+  }
+#endif
 
   // for (size_t i = 0; i < count; ++i) prepare_rmd(rs[i]);
   for (size_t i = 0; i < count; ++i) {
@@ -112,8 +130,26 @@ void addr65_batch(h160_t *hashes, const pe *points, size_t count) {
   u8 msg[HASH_BATCH_SIZE][65] = {0}; // sha256 payload
   u32 rs[HASH_BATCH_SIZE][16] = {0};  // sha256 output and rmd160 input
 
-  for (size_t i = 0; i < count; ++i) prepare65(msg[i], points + i);
+  u8 *msg_ptr[HASH_BATCH_SIZE];
+  u8 *dig_ptr[HASH_BATCH_SIZE];
+
+  for (size_t i = 0; i < count; ++i) {
+    prepare65(msg[i], points + i);
+    msg_ptr[i] = msg[i];
+    dig_ptr[i] = (u8 *)rs[i];
+  }
+
+#if defined(NO_SIMD) || RMD_LEN == 1
   for (size_t i = 0; i < count; ++i) sha256_final(rs[i], msg[i], 65);
+#else
+  if (count == 8 && RMD_LEN >= 8) {
+    sha256_8w(msg_ptr, 65, dig_ptr);
+  } else if (count == 4 && RMD_LEN >= 4) {
+    sha256_4w(msg_ptr, 65, dig_ptr);
+  } else {
+    for (size_t i = 0; i < count; ++i) sha256_final(rs[i], msg[i], 65);
+  }
+#endif
 
   // for (size_t i = 0; i < count; ++i) prepare_rmd(rs[i]);
   for (size_t i = 0; i < count; ++i) {

--- a/readme.md
+++ b/readme.md
@@ -31,6 +31,13 @@ _\* On macOS, you may need to run `xcode-select --install` first._
 
 By default, `cc` is used as the compiler. Using `clang` may produce [faster code](https://github.com/vladkens/ecloop/issues/7) than `gcc`. You can explicitly specify the compiler for any `make` command using the `CC` parameter. For example: `make add CC=clang`.
 
+Vectorized hashing is enabled by default. To disable all SIMD optimizations (for
+older CPUs), pass `SIMD=0` when invoking `make`:
+
+```sh
+make build SIMD=0
+```
+
 Also, verify correctness with the following commands (some compiler versions may have issues with built-ins used in the code):
 
 ```sh


### PR DESCRIPTION
## Summary
- enable SIMD by default with a `SIMD` Makefile flag
- use `sha256_4w`/`sha256_8w` in batch address hashing
- document how to disable SIMD if needed

## Testing
- `make build`
- `make add`
- `make build SIMD=0`


------
https://chatgpt.com/codex/tasks/task_e_6871c494667c8322ad3aa91d08b8ebd5