### PR TITLE
Add OpenCL xoshiro256 PRNG support

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -11,6 +11,7 @@ NASM_FMT ?= elf64
 ifeq ($(OS),Windows_NT)
     EXE := .exe
     NASM_FMT := win64
+    LDLIBS += -lbcrypt
 endif
 
 ifeq ($(shell uname -m),x86_64)

--- a/Makefile
+++ b/Makefile
@@ -2,7 +2,8 @@
 
 CC = cc
 NASM = nasm
-CC_FLAGS ?= -O3 -funroll-loops -fomit-frame-pointer -ffast-math -Wall -Wextra
+CC_FLAGS ?= -O3 -funroll-loops -fomit-frame-pointer -ffast-math -Wall -Wextra -DUSE_OPENCL
+LDLIBS ?= -lOpenCL
 
 ifeq ($(shell uname -m),x86_64)
         CC_FLAGS += -march=native -mavx2 -pthread -lpthread
@@ -17,8 +18,9 @@ build:
 	$(MAKE) clean
 	$(MAKE) xoshiro256ss-avx/xoshiro256ss.o
 	$(CC) $(CC_FLAGS) -DXOSHIRO256SS_TECH=1 -I./xoshiro256ss-avx \
-main.c xoshiro256ss-avx/xoshiro256ss.c xoshiro256ss-avx/xoshiro256ss.o -o ecloop
-
+                     main.c xoshiro256ss-avx/xoshiro256ss.c lib/rmd160_opencl.c lib/ecc_opencl.c lib/addr_opencl.c lib/sha256_opencl.c lib/utils_opencl.c lib/xoshiro_opencl.c \
+                                xoshiro256ss-avx/xoshiro256ss.o $(LDLIBS) -o ecloop
+		
 xoshiro256ss-avx/xoshiro256ss.o: xoshiro256ss-avx/xoshiro256ss.s
 	$(NASM) -Ox -felf64 -DXOSHIRO256SS_TECH=1 -o $@ $<
 

--- a/lib/addr.c
+++ b/lib/addr.c
@@ -15,6 +15,11 @@
 #define HASH_BATCH_SIZE ((size_t)RMD_LEN)
 typedef u32 h160_t[5];
 
+#ifdef USE_OPENCL
+int addr33_opencl_batch(u32 *out, const pe *points, size_t count);
+int addr65_opencl_batch(u32 *out, const pe *points, size_t count);
+#endif
+
 int compare_160(const void *a, const void *b) {
   const u32 *ua = (const u32 *)a;
   const u32 *ub = (const u32 *)b;
@@ -98,6 +103,9 @@ void addr65(u32 *r, const pe *point) {
 
 void addr33_batch(h160_t *hashes, const pe *points, size_t count) {
   assert(count <= HASH_BATCH_SIZE);
+#ifdef USE_OPENCL
+  if (addr33_opencl_batch((u32 *)hashes, points, count)) return;
+#endif
   u8 msg[HASH_BATCH_SIZE][64] = {0}; // sha256 payload
   u32 rs[HASH_BATCH_SIZE][16] = {0}; // sha256 output and rmd160 input
 
@@ -115,6 +123,9 @@ void addr33_batch(h160_t *hashes, const pe *points, size_t count) {
 
 void addr65_batch(h160_t *hashes, const pe *points, size_t count) {
   assert(count <= HASH_BATCH_SIZE);
+#ifdef USE_OPENCL
+  if (addr65_opencl_batch((u32 *)hashes, points, count)) return;
+#endif
   u8 msg[HASH_BATCH_SIZE][128] = {0}; // sha256 payload
   u32 rs[HASH_BATCH_SIZE][16] = {0};  // sha256 output and rmd160 input
 

--- a/lib/addr_opencl.c
+++ b/lib/addr_opencl.c
@@ -1,0 +1,66 @@
+#include <CL/cl.h>
+#include <stdint.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+
+typedef unsigned long long u64;
+typedef u64 fe[4];
+typedef struct { fe x; fe y; } pe;
+
+static cl_program build_program(cl_context ctx, cl_device_id dev){
+    FILE *f = fopen("lib/addr_opencl.cl", "r");
+    if(!f){ fprintf(stderr,"Failed to open addr_opencl.cl\n"); return NULL; }
+    fseek(f,0,SEEK_END); long size=ftell(f); rewind(f);
+    char *src = malloc(size+1); fread(src,1,size,f); src[size]='\0'; fclose(f);
+    const char *sources[] = {src};
+    cl_int err; cl_program p = clCreateProgramWithSource(ctx,1,sources,NULL,&err);
+    if(err!=CL_SUCCESS){ free(src); return NULL; }
+    err = clBuildProgram(p,1,&dev,"",NULL,NULL);
+    if(err!=CL_SUCCESS){
+        size_t log_size; clGetProgramBuildInfo(p,dev,CL_PROGRAM_BUILD_LOG,0,NULL,&log_size);
+        char *log = malloc(log_size+1);
+        clGetProgramBuildInfo(p,dev,CL_PROGRAM_BUILD_LOG,log_size,log,NULL);
+        log[log_size]='\0'; fprintf(stderr,"OpenCL build error:\n%s\n",log);
+        free(log); clReleaseProgram(p); p=NULL;
+    }
+    free(src); return p;
+}
+
+static int addr_batch(uint32_t *out, const pe *points, size_t count, const char *kernel_name){
+    cl_int err; cl_platform_id platform; cl_device_id device;
+    err = clGetPlatformIDs(1,&platform,NULL); if(err!=CL_SUCCESS) return 0;
+    err = clGetDeviceIDs(platform,CL_DEVICE_TYPE_GPU,1,&device,NULL); if(err!=CL_SUCCESS) return 0;
+    cl_context ctx = clCreateContext(NULL,1,&device,NULL,NULL,&err); if(err!=CL_SUCCESS) return 0;
+    cl_command_queue q = clCreateCommandQueue(ctx,device,0,&err);
+    if(err!=CL_SUCCESS){ clReleaseContext(ctx); return 0; }
+    cl_program prog = build_program(ctx,device); if(!prog){ clReleaseCommandQueue(q); clReleaseContext(ctx); return 0; }
+    cl_kernel kern = clCreateKernel(prog,kernel_name,&err);
+    if(err!=CL_SUCCESS){ clReleaseProgram(prog); clReleaseCommandQueue(q); clReleaseContext(ctx); return 0; }
+    size_t in_size = count*8*sizeof(u64);
+    size_t out_size = count*5*sizeof(uint32_t);
+    cl_mem buf_in = clCreateBuffer(ctx,CL_MEM_READ_ONLY|CL_MEM_COPY_HOST_PTR,in_size,(void*)points,&err);
+    if(err!=CL_SUCCESS){ goto cleanup; }
+    cl_mem buf_out = clCreateBuffer(ctx,CL_MEM_WRITE_ONLY,out_size,NULL,&err);
+    if(err!=CL_SUCCESS){ clReleaseMemObject(buf_in); goto cleanup; }
+    clSetKernelArg(kern,0,sizeof(buf_in),&buf_in);
+    clSetKernelArg(kern,1,sizeof(buf_out),&buf_out);
+    size_t global = count;
+    err = clEnqueueNDRangeKernel(q,kern,1,NULL,&global,NULL,0,NULL,NULL);
+    if(err!=CL_SUCCESS){ clReleaseMemObject(buf_in); clReleaseMemObject(buf_out); goto cleanup; }
+    clFinish(q);
+    err = clEnqueueReadBuffer(q,buf_out,CL_TRUE,0,out_size,out,0,NULL,NULL);
+    clReleaseMemObject(buf_in);
+    clReleaseMemObject(buf_out);
+cleanup:
+    clReleaseKernel(kern); clReleaseProgram(prog); clReleaseCommandQueue(q); clReleaseContext(ctx);
+    return err==CL_SUCCESS;
+}
+
+int addr33_opencl_batch(uint32_t *out, const pe *points, size_t count){
+    return addr_batch(out, points, count, "addr33_kernel");
+}
+
+int addr65_opencl_batch(uint32_t *out, const pe *points, size_t count){
+    return addr_batch(out, points, count, "addr65_kernel");
+}

--- a/lib/addr_opencl.cl
+++ b/lib/addr_opencl.cl
@@ -1,0 +1,147 @@
+__constant uint SHA256_K[64] = {
+    0x428A2F98,0x71374491,0xB5C0FBCF,0xE9B5DBA5,0x3956C25B,0x59F111F1,0x923F82A4,0xAB1C5ED5,
+    0xD807AA98,0x12835B01,0x243185BE,0x550C7DC3,0x72BE5D74,0x80DEB1FE,0x9BDC06A7,0xC19BF174,
+    0xE49B69C1,0xEFBE4786,0x0FC19DC6,0x240CA1CC,0x2DE92C6F,0x4A7484AA,0x5CB0A9DC,0x76F988DA,
+    0x983E5152,0xA831C66D,0xB00327C8,0xBF597FC7,0xC6E00BF3,0xD5A79147,0x06CA6351,0x14292967,
+    0x27B70A85,0x2E1B2138,0x4D2C6DFC,0x53380D13,0x650A7354,0x766A0ABB,0x81C2C92E,0x92722C85,
+    0xA2BFE8A1,0xA81A664B,0xC24B8B70,0xC76C51A3,0xD192E819,0xD6990624,0xF40E3585,0x106AA070,
+    0x19A4C116,0x1E376C08,0x2748774C,0x34B0BCB5,0x391C0CB3,0x4ED8AA4A,0x5B9CCA4F,0x682E6FF3,
+    0x748F82EE,0x78A5636F,0x84C87814,0x8CC70208,0x90BEFFFA,0xA4506CEB,0xBEF9A3F7,0xC67178F2
+};
+
+__constant uint SHA256_IV[8] = {
+    0x6a09e667,0xbb67ae85,0x3c6ef372,0xa54ff53a,0x510e527f,0x9b05688c,0x1f83d9ab,0x5be0cd19
+};
+
+__constant uint _n[80] = {
+    0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,
+    7,4,13,1,10,6,15,3,12,0,9,5,2,14,11,8,
+    3,10,14,4,9,15,8,1,2,7,0,6,13,11,5,12,
+    1,9,11,10,0,8,12,4,13,3,7,15,14,5,6,2,
+    4,0,5,9,7,12,2,10,14,1,3,8,11,6,15,13
+};
+
+__constant uchar _r[80] = {
+    11,14,15,12,5,8,7,9,11,13,14,15,6,7,9,8,
+    7,6,8,13,11,9,7,15,7,12,15,9,11,7,13,12,
+    11,13,6,7,14,9,13,15,14,8,13,6,5,12,7,5,
+    11,12,14,15,14,15,9,8,9,14,5,6,8,6,5,12,
+    9,15,5,11,6,8,13,12,5,12,13,14,11,8,5,6
+};
+
+__constant uint n_[80] = {
+    5,14,7,0,9,2,11,4,13,6,15,8,1,10,3,12,
+    6,11,3,7,0,13,5,10,14,15,8,12,4,9,1,2,
+    15,5,1,3,7,14,6,9,11,8,12,2,10,0,4,13,
+    8,6,4,1,3,11,15,0,5,12,2,13,9,7,10,14,
+    12,15,10,4,1,5,8,7,6,2,13,14,0,3,9,11
+};
+
+__constant uchar r_[80] = {
+    8,9,9,11,13,15,15,5,7,7,8,11,14,14,12,6,
+    9,13,15,7,12,8,9,11,7,7,12,7,6,15,13,11,
+    9,7,15,11,8,6,6,14,12,13,5,14,13,13,7,5,
+    15,5,8,11,14,14,6,14,6,9,12,9,12,5,15,8,
+    8,5,12,9,12,5,14,6,8,13,6,5,15,13,11,11
+};
+
+#define F1(x,y,z) ((x) ^ (y) ^ (z))
+#define F2(x,y,z) (((x)&(y)) | (~(x)&(z)))
+#define F3(x,y,z) (((x)|~(y)) ^ (z))
+#define F4(x,y,z) (((x)&(z)) | ((y)&~(z)))
+#define F5(x,y,z) ((x) ^ ((y)|~(z)))
+
+#define ROTL32(x,n) rotate((x),(n))
+#define ROTR32(x,n) rotate((x),(32-(n)))
+
+inline void store64be(ulong v,__private uchar*out){
+    out[0]=(uchar)(v>>56); out[1]=(uchar)(v>>48); out[2]=(uchar)(v>>40); out[3]=(uchar)(v>>32);
+    out[4]=(uchar)(v>>24); out[5]=(uchar)(v>>16); out[6]=(uchar)(v>>8); out[7]=(uchar)v;
+}
+
+inline void sha256_init(__private uint S[8]){
+    for(int i=0;i<8;i++) S[i]=SHA256_IV[i];
+}
+
+inline void sha256_process_block(__private uint S[8], __private const uchar block[64]){
+    __private uint w[64];
+    for(int i=0;i<16;i++){
+        int k=i*4;
+        w[i]=((uint)block[k]<<24)|((uint)block[k+1]<<16)|((uint)block[k+2]<<8)|block[k+3];
+    }
+    for(int i=16;i<64;i++){
+        uint x=w[i-15];
+        uint y=w[i-2];
+        uint s0=ROTR32(x,7)^ROTR32(x,18)^(x>>3);
+        uint s1=ROTR32(y,17)^ROTR32(y,19)^(y>>10);
+        w[i]=w[i-16]+s0+w[i-7]+s1;
+    }
+    uint a=S[0],b=S[1],c=S[2],d=S[3],e=S[4],f=S[5],g=S[6],h=S[7];
+    for(int i=0;i<64;i++){
+        uint t1=h+(ROTR32(e,6)^ROTR32(e,11)^ROTR32(e,25))+((e&f)^((~e)&g))+SHA256_K[i]+w[i];
+        uint t2=(ROTR32(a,2)^ROTR32(a,13)^ROTR32(a,22))+((a&b)^(a&c)^(b&c));
+        h=g; g=f; f=e; e=d+t1; d=c; c=b; b=a; a=t1+t2;
+    }
+    S[0]+=a; S[1]+=b; S[2]+=c; S[3]+=d; S[4]+=e; S[5]+=f; S[6]+=g; S[7]+=h;
+}
+
+inline void sha256(const __private uchar *msg,int blocks,__private uint digest[8]){
+    sha256_init(digest);
+    for(int i=0;i<blocks;i++) sha256_process_block(digest,msg+i*64);
+}
+
+inline void rmd160_process(__private uint state[5], __private const uint x[16]){
+    uint a1,b1,c1,d1,e1,a2,b2,c2,d2,e2,alpha,beta;
+    a1=a2=0x67452301u; b1=b2=0xefcdab89u; c1=c2=0x98badcfeu; d1=d2=0x10325476u; e1=e2=0xc3d2e1f0u;
+    for(int i=0;i<16;i++){ alpha=a1+F1(b1,c1,d1)+x[_n[i]]; alpha=ROTL32(alpha,_r[i])+e1; beta=ROTL32(c1,10); a1=e1; c1=b1; e1=d1; b1=alpha; d1=beta; alpha=a2+F5(b2,c2,d2)+x[n_[i]]+0x50a28be6u; alpha=ROTL32(alpha,r_[i])+e2; beta=ROTL32(c2,10); a2=e2; c2=b2; e2=d2; b2=alpha; d2=beta; }
+    for(int i=16;i<32;i++){ alpha=a1+F2(b1,c1,d1)+x[_n[i]]+0x5a827999u; alpha=ROTL32(alpha,_r[i])+e1; beta=ROTL32(c1,10); a1=e1; c1=b1; e1=d1; b1=alpha; d1=beta; alpha=a2+F4(b2,c2,d2)+x[n_[i]]+0x5c4dd124u; alpha=ROTL32(alpha,r_[i])+e2; beta=ROTL32(c2,10); a2=e2; c2=b2; e2=d2; b2=alpha; d2=beta; }
+    for(int i=32;i<48;i++){ alpha=a1+F3(b1,c1,d1)+x[_n[i]]+0x6ed9eba1u; alpha=ROTL32(alpha,_r[i])+e1; beta=ROTL32(c1,10); a1=e1; c1=b1; e1=d1; b1=alpha; d1=beta; alpha=a2+F3(b2,c2,d2)+x[n_[i]]+0x6d703ef3u; alpha=ROTL32(alpha,r_[i])+e2; beta=ROTL32(c2,10); a2=e2; c2=b2; e2=d2; b2=alpha; d2=beta; }
+    for(int i=48;i<64;i++){ alpha=a1+F4(b1,c1,d1)+x[_n[i]]+0x8f1bbcdcu; alpha=ROTL32(alpha,_r[i])+e1; beta=ROTL32(c1,10); a1=e1; c1=b1; e1=d1; b1=alpha; d1=beta; alpha=a2+F2(b2,c2,d2)+x[n_[i]]+0x7a6d76e9u; alpha=ROTL32(alpha,r_[i])+e2; beta=ROTL32(c2,10); a2=e2; c2=b2; e2=d2; b2=alpha; d2=beta; }
+    for(int i=64;i<80;i++){ alpha=a1+F5(b1,c1,d1)+x[_n[i]]+0xa953fd4eu; alpha=ROTL32(alpha,_r[i])+e1; beta=ROTL32(c1,10); a1=e1; c1=b1; e1=d1; b1=alpha; d1=beta; alpha=a2+F1(b2,c2,d2)+x[n_[i]]; alpha=ROTL32(alpha,r_[i])+e2; beta=ROTL32(c2,10); a2=e2; c2=b2; e2=d2; b2=alpha; d2=beta; }
+    d2+=c1+0xefcdab89u; state[1]=0x98badcfeu+d1+e2; state[2]=0x10325476u+e1+a2; state[3]=0xc3d2e1f0u+a1+b2; state[4]=0x67452301u+b1+c2; state[0]=d2;
+    for(int i=0;i<5;i++) state[i]=as_uint(as_uchar4(state[i]).s3210);
+}
+
+__kernel void addr33_kernel(__global const ulong *pts, __global uint *out){
+    uint gid=get_global_id(0);
+    const ulong *p=pts+gid*8;
+    ulong x3=p[3],x2=p[2],x1=p[1],x0=p[0];
+    ulong y0=p[4];
+    uchar msg[64]={0};
+    msg[0]=(y0&1)?0x03:0x02;
+    store64be(x3,msg+1);
+    store64be(x2,msg+9);
+    store64be(x1,msg+17);
+    store64be(x0,msg+25);
+    msg[33]=0x80; msg[62]=0x01; msg[63]=0x08;
+    uint sha[8];
+    sha256(msg,1,sha);
+    uint block[16]={0};
+    for(int i=0;i<8;i++) block[i]=as_uint(as_uchar4(sha[i]).s3210);
+    block[8]=0x80000000u; block[14]=256u;
+    uint rmd[5];
+    rmd160_process(rmd,block);
+    __global uint *dst=out+gid*5;
+    for(int i=0;i<5;i++) dst[i]=rmd[i];
+}
+
+__kernel void addr65_kernel(__global const ulong *pts, __global uint *out){
+    uint gid=get_global_id(0);
+    const ulong *p=pts+gid*8;
+    ulong x3=p[3],x2=p[2],x1=p[1],x0=p[0];
+    ulong y3=p[7],y2=p[6],y1=p[5],y0=p[4];
+    uchar msg[128]={0};
+    msg[0]=0x04;
+    store64be(x3,msg+1); store64be(x2,msg+9); store64be(x1,msg+17); store64be(x0,msg+25);
+    store64be(y3,msg+33); store64be(y2,msg+41); store64be(y1,msg+49); store64be(y0,msg+57);
+    msg[65]=0x80; msg[126]=0x02; msg[127]=0x08;
+    uint sha[8];
+    sha256(msg,2,sha);
+    uint block[16]={0};
+    for(int i=0;i<8;i++) block[i]=as_uint(as_uchar4(sha[i]).s3210);
+    block[8]=0x80000000u; block[14]=256u;
+    uint rmd[5];
+    rmd160_process(rmd,block);
+    __global uint *dst=out+gid*5;
+    for(int i=0;i<5;i++) dst[i]=rmd[i];
+}

--- a/lib/ecc_opencl.c
+++ b/lib/ecc_opencl.c
@@ -1,0 +1,51 @@
+#include <CL/cl.h>
+#include <stdint.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+
+typedef unsigned long long u64;
+
+typedef u64 fe[4];
+typedef struct { fe x; fe y; } pe;
+
+static cl_program build_program(cl_context ctx, cl_device_id dev){
+    FILE *f=fopen("lib/ecc_opencl.cl","r");
+    if(!f){ fprintf(stderr,"Failed to open ecc_opencl.cl\n"); return NULL; }
+    fseek(f,0,SEEK_END); long size=ftell(f); rewind(f);
+    char *src=malloc(size+1); fread(src,1,size,f); src[size]='\0'; fclose(f);
+    const char *sources[]={src};
+    cl_int err; cl_program p=clCreateProgramWithSource(ctx,1,sources,NULL,&err);
+    if(err!=CL_SUCCESS){ free(src); return NULL; }
+    err=clBuildProgram(p,1,&dev,"",NULL,NULL);
+    if(err!=CL_SUCCESS){
+        size_t log_size; clGetProgramBuildInfo(p,dev,CL_PROGRAM_BUILD_LOG,0,NULL,&log_size);
+        char *log=malloc(log_size+1);
+        clGetProgramBuildInfo(p,dev,CL_PROGRAM_BUILD_LOG,log_size,log,NULL);
+        log[log_size]='\0'; fprintf(stderr,"OpenCL build error:\n%s\n",log);
+        free(log); clReleaseProgram(p); p=NULL;
+    }
+    free(src); return p;
+}
+
+int ecc_mul_opencl_batch(pe *out,const fe *scalars,size_t count){
+    cl_int err; cl_platform_id platform; cl_device_id device;
+    err=clGetPlatformIDs(1,&platform,NULL); if(err!=CL_SUCCESS) return 0;
+    err=clGetDeviceIDs(platform,CL_DEVICE_TYPE_GPU,1,&device,NULL); if(err!=CL_SUCCESS) return 0;
+    cl_context ctx=clCreateContext(NULL,1,&device,NULL,NULL,&err); if(err!=CL_SUCCESS) return 0;
+    cl_command_queue q=clCreateCommandQueue(ctx,device,0,&err);
+    if(err!=CL_SUCCESS){ clReleaseContext(ctx); return 0; }
+    cl_program prog=build_program(ctx,device); if(!prog){ clReleaseCommandQueue(q); clReleaseContext(ctx); return 0; }
+    cl_kernel kern=clCreateKernel(prog,"ecc_mul_kernel",&err); if(err!=CL_SUCCESS){ clReleaseProgram(prog); clReleaseCommandQueue(q); clReleaseContext(ctx); return 0; }
+    size_t in_size=count*4*sizeof(u64); size_t out_size=count*8*sizeof(u64);
+    cl_mem buf_in=clCreateBuffer(ctx,CL_MEM_READ_ONLY|CL_MEM_COPY_HOST_PTR,in_size,(void*)scalars,&err); if(err!=CL_SUCCESS) goto cleanup;
+    cl_mem buf_out=clCreateBuffer(ctx,CL_MEM_WRITE_ONLY,out_size,NULL,&err); if(err!=CL_SUCCESS){ clReleaseMemObject(buf_in); goto cleanup; }
+    clSetKernelArg(kern,0,sizeof(buf_out),&buf_out);
+    clSetKernelArg(kern,1,sizeof(buf_in),&buf_in);
+    size_t global=count; err=clEnqueueNDRangeKernel(q,kern,1,NULL,&global,NULL,0,NULL,NULL); if(err!=CL_SUCCESS){ clReleaseMemObject(buf_in); clReleaseMemObject(buf_out); goto cleanup; }
+    clFinish(q);
+    err=clEnqueueReadBuffer(q,buf_out,CL_TRUE,0,out_size,out,0,NULL,NULL);
+    clReleaseMemObject(buf_in); clReleaseMemObject(buf_out);
+cleanup:
+    clReleaseKernel(kern); clReleaseProgram(prog); clReleaseCommandQueue(q); clReleaseContext(ctx); return err==CL_SUCCESS;
+}

--- a/lib/ecc_opencl.cl
+++ b/lib/ecc_opencl.cl
@@ -1,0 +1,342 @@
+// OpenCL kernel for secp256k1 scalar multiplication
+
+#pragma OPENCL EXTENSION cl_khr_int64_base_atomics : enable
+
+// 64bit add with carry
+inline ulong addc64(ulong x, ulong y, ulong carry, __private ulong *co){
+    ulong r = x + y;
+    ulong c1 = r < x;
+    r += carry;
+    ulong c2 = r < carry;
+    *co = c1 | c2;
+    return r;
+}
+
+// 64bit sub with borrow
+inline ulong subc64(ulong x, ulong y, ulong carry, __private ulong *bo){
+    ulong r = x - y;
+    ulong b1 = r > x;
+    r -= carry;
+    ulong b2 = r > (ulong)(-carry-1);
+    *bo = b1 | b2;
+    return r;
+}
+
+inline ulong umul128(ulong a, ulong b, __private ulong *hi){
+    ulong lo = a * b;
+    *hi = mul_hi(a,b);
+    return lo;
+}
+
+typedef ulong fe[4];
+typedef ulong fe320[5];
+
+constant fe FE_P = {0xfffffffefffffc2fUL, 0xffffffffffffffffUL, 0xffffffffffffffffUL, 0xffffffffffffffffUL};
+
+inline int fe_cmp(const fe a, const fe b){
+    for(int i=3;i>=0;--i){
+        if(a[i]!=b[i]) return a[i]>b[i]?1:-1;
+    }
+    return 0;
+}
+
+inline void fe_clone(fe r, const fe a){
+    for(int i=0;i<4;i++) r[i]=a[i];
+}
+
+inline void fe_mul_scalar(fe320 r, const fe a, ulong b){
+    ulong h1,h2,c=0;
+    r[0]=umul128(a[0],b,&h1);
+    r[1]=addc64(umul128(a[1],b,&h2),h1,c,&c);
+    r[2]=addc64(umul128(a[2],b,&h1),h2,c,&c);
+    r[3]=addc64(umul128(a[3],b,&h2),h1,c,&c);
+    r[4]=addc64(0,h2,c,&c);
+}
+
+inline ulong fe320_addc(fe320 r,const fe320 a,const fe320 b){
+    ulong c=0;
+    r[0]=addc64(a[0],b[0],c,&c);
+    r[1]=addc64(a[1],b[1],c,&c);
+    r[2]=addc64(a[2],b[2],c,&c);
+    r[3]=addc64(a[3],b[3],c,&c);
+    r[4]=addc64(a[4],b[4],c,&c);
+    return c;
+}
+
+inline ulong fe320_subc(fe320 r,const fe320 a,const fe320 b){
+    ulong c=0;
+    r[0]=subc64(a[0],b[0],c,&c);
+    r[1]=subc64(a[1],b[1],c,&c);
+    r[2]=subc64(a[2],b[2],c,&c);
+    r[3]=subc64(a[3],b[3],c,&c);
+    r[4]=subc64(a[4],b[4],c,&c);
+    return c;
+}
+
+// Field operations mod P
+inline void fe_modp_add(fe r,const fe a,const fe b){
+    ulong c=0;
+    r[0]=addc64(a[0],b[0],c,&c);
+    r[1]=addc64(a[1],b[1],c,&c);
+    r[2]=addc64(a[2],b[2],c,&c);
+    r[3]=addc64(a[3],b[3],c,&c);
+    if(c || fe_cmp(r,FE_P)>=0){
+        c=0;
+        r[0]=subc64(r[0],FE_P[0],c,&c);
+        r[1]=subc64(r[1],FE_P[1],c,&c);
+        r[2]=subc64(r[2],FE_P[2],c,&c);
+        r[3]=subc64(r[3],FE_P[3],c,&c);
+    }
+}
+
+inline void fe_modp_sub(fe r,const fe a,const fe b){
+    ulong c=0;
+    r[0]=subc64(a[0],b[0],c,&c);
+    r[1]=subc64(a[1],b[1],c,&c);
+    r[2]=subc64(a[2],b[2],c,&c);
+    r[3]=subc64(a[3],b[3],c,&c);
+    if(c){
+        c=0;
+        r[0]=addc64(r[0],FE_P[0],0,&c);
+        r[1]=addc64(r[1],FE_P[1],c,&c);
+        r[2]=addc64(r[2],FE_P[2],c,&c);
+        r[3]=addc64(r[3],FE_P[3],c,&c);
+    }
+}
+
+inline void fe_modp_mul(fe r,const fe a,const fe b){
+    ulong rr[8]={0},tt[5]={0},c=0;
+    fe_mul_scalar(rr,a,b[0]);
+    fe_mul_scalar(tt,a,b[1]);
+    rr[1]=addc64(rr[1],tt[0],c,&c);
+    rr[2]=addc64(rr[2],tt[1],c,&c);
+    rr[3]=addc64(rr[3],tt[2],c,&c);
+    rr[4]=addc64(rr[4],tt[3],c,&c);
+    rr[5]=addc64(rr[5],tt[4],c,&c);
+    fe_mul_scalar(tt,a,b[2]);
+    rr[2]=addc64(rr[2],tt[0],c,&c);
+    rr[3]=addc64(rr[3],tt[1],c,&c);
+    rr[4]=addc64(rr[4],tt[2],c,&c);
+    rr[5]=addc64(rr[5],tt[3],c,&c);
+    rr[6]=addc64(rr[6],tt[4],c,&c);
+    fe_mul_scalar(tt,a,b[3]);
+    rr[3]=addc64(rr[3],tt[0],c,&c);
+    rr[4]=addc64(rr[4],tt[1],c,&c);
+    rr[5]=addc64(rr[5],tt[2],c,&c);
+    rr[6]=addc64(rr[6],tt[3],c,&c);
+    rr[7]=addc64(rr[7],tt[4],c,&c);
+    fe_mul_scalar(tt,rr+4,0x1000003D1UL);
+    rr[0]=addc64(rr[0],tt[0],0,&c);
+    rr[1]=addc64(rr[1],tt[1],c,&c);
+    rr[2]=addc64(rr[2],tt[2],c,&c);
+    rr[3]=addc64(rr[3],tt[3],c,&c);
+    ulong hi,lo;
+    lo=umul128(tt[4]+c,0x1000003D1UL,&hi);
+    r[0]=addc64(rr[0],lo,0,&c);
+    r[1]=addc64(rr[1],hi,c,&c);
+    r[2]=addc64(rr[2],0,c,&c);
+    r[3]=addc64(rr[3],0,c,&c);
+    if(fe_cmp(r,FE_P)>=0) fe_modp_sub(r,r,FE_P);
+}
+
+inline void fe_modp_sqr(fe r,const fe a){
+    ulong rr[8]={0},tt[5]={0},c=0,t1,t2,lo,hi;
+    rr[0]=umul128(a[0],a[0],&tt[1]);
+    tt[3]=umul128(a[0],a[1],&tt[4]);
+    tt[3]=addc64(tt[3],tt[3],0,&c);
+    tt[4]=addc64(tt[4],tt[4],c,&c);
+    t1=c;
+    tt[3]=addc64(tt[1],tt[3],0,&c);
+    tt[4]=addc64(tt[4],0,c,&c);
+    t1+=c;
+    rr[1]=tt[3];
+    tt[0]=umul128(a[0],a[2],&tt[1]);
+    tt[0]=addc64(tt[0],tt[0],0,&c);
+    tt[1]=addc64(tt[1],tt[1],c,&c);
+    t2=c;
+    lo=umul128(a[1],a[1],&hi);
+    tt[0]=addc64(tt[0],lo,0,&c);
+    tt[1]=addc64(tt[1],hi,c,&c);
+    t2+=c;
+    tt[0]=addc64(tt[0],tt[4],0,&c);
+    tt[1]=addc64(tt[1],t1,c,&c);
+    t2+=c;
+    rr[2]=tt[0];
+    tt[3]=umul128(a[0],a[3],&tt[4]);
+    lo=umul128(a[1],a[2],&hi);
+    tt[3]=addc64(tt[3],lo,0,&c);
+    tt[4]=addc64(tt[4],hi,c,&c);
+    t1=c+c;
+    tt[3]=addc64(tt[3],tt[3],0,&c);
+    tt[4]=addc64(tt[4],tt[4],c,&c);
+    t1+=c;
+    tt[3]=addc64(tt[1],tt[3],0,&c);
+    tt[4]=addc64(tt[4],t2,c,&c);
+    t1+=c;
+    rr[3]=tt[3];
+    tt[0]=umul128(a[1],a[3],&tt[1]);
+    tt[0]=addc64(tt[0],tt[0],0,&c);
+    tt[1]=addc64(tt[1],tt[1],c,&c);
+    t2=c;
+    lo=umul128(a[2],a[2],&hi);
+    tt[0]=addc64(tt[0],lo,0,&c);
+    tt[1]=addc64(tt[1],hi,c,&c);
+    t2+=c;
+    tt[0]=addc64(tt[0],tt[4],0,&c);
+    tt[1]=addc64(tt[1],t1,c,&c);
+    t2+=c;
+    rr[4]=tt[0];
+    tt[3]=umul128(a[2],a[3],&tt[4]);
+    tt[3]=addc64(tt[3],tt[3],0,&c);
+    tt[4]=addc64(tt[4],tt[4],c,&c);
+    t1=c;
+    tt[3]=addc64(tt[3],tt[1],0,&c);
+    tt[4]=addc64(tt[4],t2,c,&c);
+    t1+=c;
+    rr[5]=tt[3];
+    tt[0]=umul128(a[3],a[3],&tt[1]);
+    tt[0]=addc64(tt[0],tt[4],0,&c);
+    tt[1]=addc64(tt[1],t1,c,&c);
+    rr[6]=tt[0];
+    rr[7]=tt[1];
+    fe_mul_scalar(tt,rr+4,0x1000003D1UL);
+    rr[0]=addc64(rr[0],tt[0],0,&c);
+    rr[1]=addc64(rr[1],tt[1],c,&c);
+    rr[2]=addc64(rr[2],tt[2],c,&c);
+    rr[3]=addc64(rr[3],tt[3],c,&c);
+    lo=umul128(tt[4]+c,0x1000003D1UL,&hi);
+    r[0]=addc64(rr[0],lo,0,&c);
+    r[1]=addc64(rr[1],hi,c,&c);
+    r[2]=addc64(rr[2],0,c,&c);
+    r[3]=addc64(rr[3],0,c,&c);
+    if(fe_cmp(r,FE_P)>=0) fe_modp_sub(r,r,FE_P);
+}
+
+// Elliptic curve point
+typedef struct { fe x; fe y; fe z; } pe;
+constant pe G1 = {
+    {0x59f2815b16f81798UL,0x029bfcdb2dce28d9UL,0x55a06295ce870b07UL,0x79be667ef9dcbbacUL},
+    {0x9c47d08ffb10d4b8UL,0xfd17b448a6855419UL,0x5da4fbfc0e1108a8UL,0x483ada7726a3c465UL},
+    {1UL,0UL,0UL,0UL}
+};
+
+inline void pe_clone(__private pe *r, __private const pe *a){
+    for(int i=0;i<4;i++){ r->x[i]=a->x[i]; r->y[i]=a->y[i]; r->z[i]=a->z[i]; }
+}
+
+inline void fe_modp_neg(fe r,const fe a){
+    ulong c=0;
+    r[0]=subc64(FE_P[0],a[0],c,&c);
+    r[1]=subc64(FE_P[1],a[1],c,&c);
+    r[2]=subc64(FE_P[2],a[2],c,&c);
+    r[3]=subc64(FE_P[3],a[3],c,&c);
+}
+
+inline void _ec_jacobi_dbl1(__private pe *r,__private const pe *p){
+    fe w,s,b,h,t;
+    fe_modp_sqr(t,p->x);
+    fe_modp_add(w,t,t);
+    fe_modp_add(w,w,t);
+    fe_modp_mul(s,p->y,p->z);
+    fe_modp_mul(b,p->x,p->y);
+    fe_modp_mul(b,b,s);
+    fe_modp_add(b,b,b);
+    fe_modp_add(b,b,b);
+    fe_modp_add(t,b,b);
+    fe_modp_sqr(h,w);
+    fe_modp_sub(h,h,t);
+    fe_modp_mul(r->x,h,s);
+    fe_modp_add(r->x,r->x,r->x);
+    fe_modp_sub(t,b,h);
+    fe_modp_mul(t,w,t);
+    fe_modp_sqr(r->y,p->y);
+    fe_modp_sqr(h,s);
+    fe_modp_mul(r->y,r->y,h);
+    fe_modp_add(r->y,r->y,r->y);
+    fe_modp_add(r->y,r->y,r->y);
+    fe_modp_add(r->y,r->y,r->y);
+    fe_modp_sub(r->y,t,r->y);
+    fe_modp_mul(r->z,h,s);
+    fe_modp_add(r->z,r->z,r->z);
+    fe_modp_add(r->z,r->z,r->z);
+    fe_modp_add(r->z,r->z,r->z);
+}
+
+inline void _ec_jacobi_add1(__private pe *r, __private const pe *p, __private const pe *q){
+    fe u2,v2,u,v,w,a,vs,vc;
+    fe_modp_mul(u2,p->y,q->z);
+    fe_modp_mul(v2,p->x,q->z);
+    fe_modp_mul(u,q->y,p->z);
+    fe_modp_mul(v,q->x,p->z);
+    if(! (v[0]==v2[0] && v[1]==v2[1] && v[2]==v2[2] && v[3]==v2[3]) ){
+        fe_modp_mul(w,p->z,q->z);
+        fe_modp_sub(u,u,u2);
+        fe_modp_sub(v,v,v2);
+        fe_modp_sqr(vs,v);
+        fe_modp_mul(vc,vs,v);
+        fe_modp_mul(vs,vs,v2);
+        fe_modp_mul(r->z,vc,w);
+        fe_modp_sqr(a,u);
+        fe_modp_mul(a,a,w);
+        fe_modp_add(w,vs,vs);
+        fe_modp_sub(a,a,vc);
+        fe_modp_sub(a,a,w);
+        fe_modp_mul(r->x,v,a);
+        fe_modp_sub(a,vs,a);
+        fe_modp_mul(a,a,u);
+        fe_modp_mul(u,vc,u2);
+        fe_modp_sub(r->y,a,u);
+    } else {
+        pe_clone(r,p);
+    }
+}
+
+inline void _ec_jacobi_rdc1(__private pe *r,__private const pe *a){
+    fe_clone(r->z,a->z);
+    fe_modp_inv(r->z,r->z);
+    fe_modp_mul(r->x,a->x,r->z);
+    fe_modp_mul(r->y,a->y,r->z);
+    r->z[0]=1; r->z[1]=0; r->z[2]=0; r->z[3]=0;
+}
+
+inline void fe_modp_inv(fe r,const fe a){
+    // binary exponentiation a^(P-2)
+    fe q={1,0,0,0},p,t;
+    fe_clone(p,FE_P);
+    fe_clone(t,a);
+    p[0]-=2;
+    while(p[0]||p[1]||p[2]||p[3]){
+        if(p[0]&1) fe_modp_mul(q,q,t);
+        fe_modp_sqr(t,t);
+        // shift right
+        ulong c=0; c=p[1]<<63; p[1]=(p[1]>>1)|(p[2]<<63); p[2]=(p[2]>>1)|(p[3]<<63); p[3]>>=1; p[0]=(p[0]>>1)|c;
+    }
+    fe_clone(r,q);
+}
+
+inline void ec_jacobi_mul(__private pe *r,__private const pe *p,__private const fe k){
+    pe t; pe_clone(&t,p);
+    r->x[0]=r->y[0]=0; r->x[1]=r->y[1]=0; r->x[2]=r->y[2]=0; r->x[3]=r->y[3]=0;
+    r->z[0]=1; r->z[1]=r->z[2]=r->z[3]=0;
+    for(int i=0;i<256;i++){
+        if(k[i/64] & (1UL<<(i%64))){
+            if(r->x[0]==0 && r->y[0]==0) pe_clone(r,&t); else _ec_jacobi_add1(r,r,&t);
+        }
+        _ec_jacobi_dbl1(&t,&t);
+    }
+}
+
+inline void ec_jacobi_mulrdc(__private pe *r,__private const pe *p,__private const fe k){
+    ec_jacobi_mul(r,p,k);
+    _ec_jacobi_rdc1(r,r);
+}
+
+__kernel void ecc_mul_kernel(__global ulong *out, __global const ulong *scalars){
+    uint gid=get_global_id(0);
+    fe k; for(int i=0;i<4;i++) k[i]=scalars[gid*4+i];
+    pe res; ec_jacobi_mulrdc(&res,&G1,k);
+    __global ulong *dst=out+gid*8;
+    for(int i=0;i<4;i++) dst[i]=res.x[i];
+    for(int i=0;i<4;i++) dst[4+i]=res.y[i];
+}
+

--- a/lib/rmd160_opencl.c
+++ b/lib/rmd160_opencl.c
@@ -1,0 +1,90 @@
+#include <CL/cl.h>
+#include <stdint.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+
+static const char *kernel_source =
+"#include \"rmd160_opencl.cl\"\n"; // loaded from header
+
+static cl_program build_program(cl_context ctx, cl_device_id dev) {
+    FILE *f = fopen("lib/rmd160_opencl.cl", "r");
+    if(!f){
+        fprintf(stderr, "Failed to open kernel file\n");
+        return NULL;
+    }
+    fseek(f,0,SEEK_END);
+    long size = ftell(f);
+    rewind(f);
+    char *src = malloc(size+1);
+    fread(src,1,size,f);
+    src[size] = '\0';
+    fclose(f);
+    const char *sources[] = {src};
+    cl_int err;
+    cl_program program = clCreateProgramWithSource(ctx,1,sources,NULL,&err);
+    if(err!=CL_SUCCESS){
+        free(src);
+        return NULL;
+    }
+    err = clBuildProgram(program,1,&dev,"",NULL,NULL);
+    if(err!=CL_SUCCESS){
+        size_t log_size;
+        clGetProgramBuildInfo(program,dev,CL_PROGRAM_BUILD_LOG,0,NULL,&log_size);
+        char *log = malloc(log_size+1);
+        clGetProgramBuildInfo(program,dev,CL_PROGRAM_BUILD_LOG,log_size,log,NULL);
+        log[log_size] = '\0';
+        fprintf(stderr,"OpenCL build error:\n%s\n",log);
+        free(log);
+        clReleaseProgram(program);
+        program = NULL;
+    }
+    free(src);
+    return program;
+}
+
+int rmd160_opencl_batch(uint32_t *out, const uint32_t *in, size_t count){
+    cl_int err;
+    cl_platform_id platform;
+    cl_device_id device;
+    err = clGetPlatformIDs(1,&platform,NULL);
+    if(err!=CL_SUCCESS) return 0;
+    err = clGetDeviceIDs(platform,CL_DEVICE_TYPE_GPU,1,&device,NULL);
+    if(err!=CL_SUCCESS) return 0;
+    cl_context ctx = clCreateContext(NULL,1,&device,NULL,NULL,&err);
+    if(err!=CL_SUCCESS) return 0;
+    cl_command_queue q = clCreateCommandQueue(ctx,device,0,&err);
+    if(err!=CL_SUCCESS){ clReleaseContext(ctx); return 0; }
+    cl_program prog = build_program(ctx,device);
+    if(!prog){ clReleaseCommandQueue(q); clReleaseContext(ctx); return 0; }
+    cl_kernel kernel = clCreateKernel(prog,"rmd160_kernel",&err);
+    if(err!=CL_SUCCESS){
+        clReleaseProgram(prog); clReleaseCommandQueue(q); clReleaseContext(ctx); return 0;
+    }
+
+    size_t in_size = count*16*sizeof(uint32_t);
+    size_t out_size = count*5*sizeof(uint32_t);
+    cl_mem buf_in = clCreateBuffer(ctx,CL_MEM_READ_ONLY|CL_MEM_COPY_HOST_PTR,in_size,(void*)in,&err);
+    if(err!=CL_SUCCESS){ goto cleanup; }
+    cl_mem buf_out = clCreateBuffer(ctx,CL_MEM_WRITE_ONLY,out_size,NULL,&err);
+    if(err!=CL_SUCCESS){ clReleaseMemObject(buf_in); goto cleanup; }
+
+    clSetKernelArg(kernel,0,sizeof(buf_in),&buf_in);
+    clSetKernelArg(kernel,1,sizeof(buf_out),&buf_out);
+
+    size_t global = count;
+    err = clEnqueueNDRangeKernel(q,kernel,1,NULL,&global,NULL,0,NULL,NULL);
+    if(err!=CL_SUCCESS){ clReleaseMemObject(buf_in); clReleaseMemObject(buf_out); goto cleanup; }
+    clFinish(q);
+
+    err = clEnqueueReadBuffer(q,buf_out,CL_TRUE,0,out_size,out,0,NULL,NULL);
+
+    clReleaseMemObject(buf_in);
+    clReleaseMemObject(buf_out);
+cleanup:
+    clReleaseKernel(kernel);
+    clReleaseProgram(prog);
+    clReleaseCommandQueue(q);
+    clReleaseContext(ctx);
+    return err==CL_SUCCESS;
+}

--- a/lib/rmd160_opencl.cl
+++ b/lib/rmd160_opencl.cl
@@ -1,0 +1,121 @@
+__constant uint _n[80] = {
+    0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,
+    7,4,13,1,10,6,15,3,12,0,9,5,2,14,11,8,
+    3,10,14,4,9,15,8,1,2,7,0,6,13,11,5,12,
+    1,9,11,10,0,8,12,4,13,3,7,15,14,5,6,2,
+    4,0,5,9,7,12,2,10,14,1,3,8,11,6,15,13
+};
+
+__constant uchar _r[80] = {
+    11,14,15,12,5,8,7,9,11,13,14,15,6,7,9,8,
+    7,6,8,13,11,9,7,15,7,12,15,9,11,7,13,12,
+    11,13,6,7,14,9,13,15,14,8,13,6,5,12,7,5,
+    11,12,14,15,14,15,9,8,9,14,5,6,8,6,5,12,
+    9,15,5,11,6,8,13,12,5,12,13,14,11,8,5,6
+};
+
+__constant uint n_[80] = {
+    5,14,7,0,9,2,11,4,13,6,15,8,1,10,3,12,
+    6,11,3,7,0,13,5,10,14,15,8,12,4,9,1,2,
+    15,5,1,3,7,14,6,9,11,8,12,2,10,0,4,13,
+    8,6,4,1,3,11,15,0,5,12,2,13,9,7,10,14,
+    12,15,10,4,1,5,8,7,6,2,13,14,0,3,9,11
+};
+
+__constant uchar r_[80] = {
+    8,9,9,11,13,15,15,5,7,7,8,11,14,14,12,6,
+    9,13,15,7,12,8,9,11,7,7,12,7,6,15,13,11,
+    9,7,15,11,8,6,6,14,12,13,5,14,13,13,7,5,
+    15,5,8,11,14,14,6,14,6,9,12,9,12,5,15,8,
+    8,5,12,9,12,5,14,6,8,13,6,5,15,13,11,11
+};
+
+#define F1(x,y,z) ((x) ^ (y) ^ (z))
+#define F2(x,y,z) (((x)&(y)) | (~(x)&(z)))
+#define F3(x,y,z) (((x)|~(y)) ^ (z))
+#define F4(x,y,z) (((x)&(z)) | ((y)&~(z)))
+#define F5(x,y,z) ((x) ^ ((y)|~(z)))
+
+#define ROTL32(x,n) rotate((x),(n))
+
+__kernel void rmd160_kernel(__global const uint *in, __global uint *out){
+    uint gid = get_global_id(0);
+    const uint *x = in + gid*16;
+    uint a1,b1,c1,d1,e1,a2,b2,c2,d2,e2,alpha,beta;
+    a1=a2=0x67452301u;
+    b1=b2=0xefcdab89u;
+    c1=c2=0x98badcfeu;
+    d1=d2=0x10325476u;
+    e1=e2=0xc3d2e1f0u;
+
+    for(uint i=0;i<16;i++){
+        alpha = a1 + F1(b1,c1,d1) + x[_n[i]];
+        alpha = ROTL32(alpha,_r[i]) + e1;
+        beta = ROTL32(c1,10);
+        a1 = e1; c1 = b1; e1 = d1; b1 = alpha; d1 = beta;
+
+        alpha = a2 + F5(b2,c2,d2) + x[n_[i]] + 0x50a28be6u;
+        alpha = ROTL32(alpha,r_[i]) + e2;
+        beta = ROTL32(c2,10);
+        a2 = e2; c2 = b2; e2 = d2; b2 = alpha; d2 = beta;
+    }
+
+    for(uint i=16;i<32;i++){
+        alpha = a1 + F2(b1,c1,d1) + x[_n[i]] + 0x5a827999u;
+        alpha = ROTL32(alpha,_r[i]) + e1;
+        beta = ROTL32(c1,10);
+        a1 = e1; c1 = b1; e1 = d1; b1 = alpha; d1 = beta;
+
+        alpha = a2 + F4(b2,c2,d2) + x[n_[i]] + 0x5c4dd124u;
+        alpha = ROTL32(alpha,r_[i]) + e2;
+        beta = ROTL32(c2,10);
+        a2 = e2; c2 = b2; e2 = d2; b2 = alpha; d2 = beta;
+    }
+
+    for(uint i=32;i<48;i++){
+        alpha = a1 + F3(b1,c1,d1) + x[_n[i]] + 0x6ed9eba1u;
+        alpha = ROTL32(alpha,_r[i]) + e1;
+        beta = ROTL32(c1,10);
+        a1 = e1; c1 = b1; e1 = d1; b1 = alpha; d1 = beta;
+
+        alpha = a2 + F3(b2,c2,d2) + x[n_[i]] + 0x6d703ef3u;
+        alpha = ROTL32(alpha,r_[i]) + e2;
+        beta = ROTL32(c2,10);
+        a2 = e2; c2 = b2; e2 = d2; b2 = alpha; d2 = beta;
+    }
+
+    for(uint i=48;i<64;i++){
+        alpha = a1 + F4(b1,c1,d1) + x[_n[i]] + 0x8f1bbcdcu;
+        alpha = ROTL32(alpha,_r[i]) + e1;
+        beta = ROTL32(c1,10);
+        a1 = e1; c1 = b1; e1 = d1; b1 = alpha; d1 = beta;
+
+        alpha = a2 + F2(b2,c2,d2) + x[n_[i]] + 0x7a6d76e9u;
+        alpha = ROTL32(alpha,r_[i]) + e2;
+        beta = ROTL32(c2,10);
+        a2 = e2; c2 = b2; e2 = d2; b2 = alpha; d2 = beta;
+    }
+
+    for(uint i=64;i<80;i++){
+        alpha = a1 + F5(b1,c1,d1) + x[_n[i]] + 0xa953fd4eu;
+        alpha = ROTL32(alpha,_r[i]) + e1;
+        beta = ROTL32(c1,10);
+        a1 = e1; c1 = b1; e1 = d1; b1 = alpha; d1 = beta;
+
+        alpha = a2 + F1(b2,c2,d2) + x[n_[i]];
+        alpha = ROTL32(alpha,r_[i]) + e2;
+        beta = ROTL32(c2,10);
+        a2 = e2; c2 = b2; e2 = d2; b2 = alpha; d2 = beta;
+    }
+
+    d2 += c1 + 0xefcdab89u;
+    state[1] = 0x98badcfeu + d1 + e2;
+    state[2] = 0x10325476u + e1 + a2;
+    state[3] = 0xc3d2e1f0u + a1 + b2;
+    state[4] = 0x67452301u + b1 + c2;
+    state[0] = d2;
+
+    for(int i=0;i<5;i++) state[i] = as_uint(as_uchar4(state[i]).s3210);
+    __global uint *dst = out + gid*5;
+    for(int i=0;i<5;i++) dst[i] = state[i];
+}

--- a/lib/sha256.c
+++ b/lib/sha256.c
@@ -5,6 +5,10 @@
 #pragma once
 #include "compat.c"
 
+#ifdef USE_OPENCL
+int sha256_opencl_batch(u32 *out, const u8 *data, size_t blocks, size_t count);
+#endif
+
 static const u32 SHA256_K[64] = {
     0x428A2F98, 0x71374491, 0xB5C0FBCF, 0xE9B5DBA5, 0x3956C25B, 0x59F111F1, 0x923F82A4, 0xAB1C5ED5,
     0xD807AA98, 0x12835B01, 0x243185BE, 0x550C7DC3, 0x72BE5D74, 0x80DEB1FE, 0x9BDC06A7, 0xC19BF174,
@@ -25,6 +29,10 @@ static const u32 SHA256_IV[8] = {
   #include <arm_neon.h>
 
 void sha256_final(u32 state[8], const u8 data[], u32 length) {
+#ifdef USE_OPENCL
+  if (length % 64 == 0 && sha256_opencl_batch(state, data, length/64, 1))
+    return;
+#endif
   uint32x4_t STATE0, STATE1, ABEF_SAVE, CDGH_SAVE;
   uint32x4_t MSG0, MSG1, MSG2, MSG3;
   uint32x4_t TMP0, TMP1, TMP2;
@@ -192,6 +200,10 @@ void sha256_final(u32 state[8], const u8 data[], u32 length) {
   #include <immintrin.h>
 
 void sha256_final(u32 state[8], const u8 data[], u32 length) {
+#ifdef USE_OPENCL
+  if (length % 64 == 0 && sha256_opencl_batch(state, data, length/64, 1))
+    return;
+#endif
   __m128i STATE0, STATE1;
   __m128i MSG, TMP;
   __m128i MSG0, MSG1, MSG2, MSG3;
@@ -397,6 +409,10 @@ static inline void ROUND(u32 a, u32 b, u32 c, u32 *d, u32 e, u32 f, u32 g, u32 *
 }
 
 void sha256_final(u32 state[8], const u8 data[], u32 length) {
+#ifdef USE_OPENCL
+  if (length % 64 == 0 && sha256_opencl_batch(state, data, length/64, 1))
+    return;
+#endif
   u32 s0, s1;
   u32 a, b, c, d, e, f, g, h;
   for (int i = 0; i < 8; i++) state[i] = SHA256_IV[i];

--- a/lib/sha256_opencl.c
+++ b/lib/sha256_opencl.c
@@ -1,0 +1,48 @@
+#include <CL/cl.h>
+#include <stdint.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+
+static cl_program build_program(cl_context ctx, cl_device_id dev){
+    FILE *f=fopen("lib/sha256_opencl.cl","r");
+    if(!f){ fprintf(stderr,"Failed to open sha256_opencl.cl\n"); return NULL; }
+    fseek(f,0,SEEK_END); long size=ftell(f); rewind(f);
+    char *src=malloc(size+1); fread(src,1,size,f); src[size]='\0'; fclose(f);
+    const char *sources[]={src};
+    cl_int err; cl_program p=clCreateProgramWithSource(ctx,1,sources,NULL,&err);
+    if(err!=CL_SUCCESS){ free(src); return NULL; }
+    err=clBuildProgram(p,1,&dev,"",NULL,NULL);
+    if(err!=CL_SUCCESS){
+        size_t log_size; clGetProgramBuildInfo(p,dev,CL_PROGRAM_BUILD_LOG,0,NULL,&log_size);
+        char *log=malloc(log_size+1);
+        clGetProgramBuildInfo(p,dev,CL_PROGRAM_BUILD_LOG,log_size,log,NULL);
+        log[log_size]='\0'; fprintf(stderr,"OpenCL build error:\n%s\n",log);
+        free(log); clReleaseProgram(p); p=NULL;
+    }
+    free(src); return p;
+}
+
+int sha256_opencl_batch(uint32_t *out, const uint8_t *in, size_t blocks, size_t count){
+    cl_int err; cl_platform_id platform; cl_device_id device;
+    err=clGetPlatformIDs(1,&platform,NULL); if(err!=CL_SUCCESS) return 0;
+    err=clGetDeviceIDs(platform,CL_DEVICE_TYPE_GPU,1,&device,NULL); if(err!=CL_SUCCESS) return 0;
+    cl_context ctx=clCreateContext(NULL,1,&device,NULL,NULL,&err); if(err!=CL_SUCCESS) return 0;
+    cl_command_queue q=clCreateCommandQueue(ctx,device,0,&err);
+    if(err!=CL_SUCCESS){ clReleaseContext(ctx); return 0; }
+    cl_program prog=build_program(ctx,device); if(!prog){ clReleaseCommandQueue(q); clReleaseContext(ctx); return 0; }
+    cl_kernel kern=clCreateKernel(prog,"sha256_kernel",&err); if(err!=CL_SUCCESS){ clReleaseProgram(prog); clReleaseCommandQueue(q); clReleaseContext(ctx); return 0; }
+    size_t in_size=count*blocks*64; size_t out_size=count*8*sizeof(uint32_t);
+    cl_mem buf_in=clCreateBuffer(ctx,CL_MEM_READ_ONLY|CL_MEM_COPY_HOST_PTR,in_size,(void*)in,&err); if(err!=CL_SUCCESS) goto cleanup;
+    cl_mem buf_out=clCreateBuffer(ctx,CL_MEM_WRITE_ONLY,out_size,NULL,&err); if(err!=CL_SUCCESS){ clReleaseMemObject(buf_in); goto cleanup; }
+    clSetKernelArg(kern,0,sizeof(buf_in),&buf_in);
+    cl_uint bl=(cl_uint)blocks; clSetKernelArg(kern,1,sizeof(bl),&bl);
+    clSetKernelArg(kern,2,sizeof(buf_out),&buf_out);
+    size_t global=count; err=clEnqueueNDRangeKernel(q,kern,1,NULL,&global,NULL,0,NULL,NULL);
+    if(err!=CL_SUCCESS){ clReleaseMemObject(buf_in); clReleaseMemObject(buf_out); goto cleanup; }
+    clFinish(q);
+    err=clEnqueueReadBuffer(q,buf_out,CL_TRUE,0,out_size,out,0,NULL,NULL);
+    clReleaseMemObject(buf_in); clReleaseMemObject(buf_out);
+cleanup:
+    clReleaseKernel(kern); clReleaseProgram(prog); clReleaseCommandQueue(q); clReleaseContext(ctx); return err==CL_SUCCESS;
+}

--- a/lib/sha256_opencl.cl
+++ b/lib/sha256_opencl.cl
@@ -1,0 +1,55 @@
+__constant uint SHA256_K[64]={
+    0x428A2F98,0x71374491,0xB5C0FBCF,0xE9B5DBA5,0x3956C25B,0x59F111F1,0x923F82A4,0xAB1C5ED5,
+    0xD807AA98,0x12835B01,0x243185BE,0x550C7DC3,0x72BE5D74,0x80DEB1FE,0x9BDC06A7,0xC19BF174,
+    0xE49B69C1,0xEFBE4786,0x0FC19DC6,0x240CA1CC,0x2DE92C6F,0x4A7484AA,0x5CB0A9DC,0x76F988DA,
+    0x983E5152,0xA831C66D,0xB00327C8,0xBF597FC7,0xC6E00BF3,0xD5A79147,0x06CA6351,0x14292967,
+    0x27B70A85,0x2E1B2138,0x4D2C6DFC,0x53380D13,0x650A7354,0x766A0ABB,0x81C2C92E,0x92722C85,
+    0xA2BFE8A1,0xA81A664B,0xC24B8B70,0xC76C51A3,0xD192E819,0xD6990624,0xF40E3585,0x106AA070,
+    0x19A4C116,0x1E376C08,0x2748774C,0x34B0BCB5,0x391C0CB3,0x4ED8AA4A,0x5B9CCA4F,0x682E6FF3,
+    0x748F82EE,0x78A5636F,0x84C87814,0x8CC70208,0x90BEFFFA,0xA4506CEB,0xBEF9A3F7,0xC67178F2
+};
+
+__constant uint SHA256_IV[8]={
+    0x6a09e667,0xbb67ae85,0x3c6ef372,0xa54ff53a,0x510e527f,0x9b05688c,0x1f83d9ab,0x5be0cd19
+};
+
+#define ROTR32(x,n) rotate((x),(32-(n)))
+
+inline void sha256_init(__private uint S[8]){
+    for(int i=0;i<8;i++) S[i]=SHA256_IV[i];
+}
+
+inline void sha256_process_block(__private uint S[8], __private const uchar block[64]){
+    __private uint w[64];
+    for(int i=0;i<16;i++){
+        int k=i*4;
+        w[i]=((uint)block[k]<<24)|((uint)block[k+1]<<16)|((uint)block[k+2]<<8)|block[k+3];
+    }
+    for(int i=16;i<64;i++){
+        uint x=w[i-15]; uint y=w[i-2];
+        uint s0=ROTR32(x,7)^ROTR32(x,18)^(x>>3);
+        uint s1=ROTR32(y,17)^ROTR32(y,19)^(y>>10);
+        w[i]=w[i-16]+s0+w[i-7]+s1;
+    }
+    uint a=S[0],b=S[1],c=S[2],d=S[3],e=S[4],f=S[5],g=S[6],h=S[7];
+    for(int i=0;i<64;i++){
+        uint t1=h+(ROTR32(e,6)^ROTR32(e,11)^ROTR32(e,25))+((e&f)^((~e)&g))+SHA256_K[i]+w[i];
+        uint t2=(ROTR32(a,2)^ROTR32(a,13)^ROTR32(a,22))+((a&b)^(a&c)^(b&c));
+        h=g; g=f; f=e; e=d+t1; d=c; c=b; b=a; a=t1+t2;
+    }
+    S[0]+=a; S[1]+=b; S[2]+=c; S[3]+=d; S[4]+=e; S[5]+=f; S[6]+=g; S[7]+=h;
+}
+
+inline void sha256(const __private uchar* msg,int blocks,__private uint digest[8]){
+    sha256_init(digest);
+    for(int i=0;i<blocks;i++) sha256_process_block(digest,msg+i*64);
+}
+
+__kernel void sha256_kernel(__global const uchar *in, uint blocks, __global uint *out){
+    uint gid=get_global_id(0);
+    const uchar *msg=in+gid*blocks*64;
+    uint dig[8];
+    sha256(msg,blocks,dig);
+    __global uint *dst=out+gid*8;
+    for(int i=0;i<8;i++) dst[i]=dig[i];
+}

--- a/lib/utils_opencl.c
+++ b/lib/utils_opencl.c
@@ -1,0 +1,66 @@
+#include <CL/cl.h>
+#include <stdint.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+
+typedef unsigned long long u64;
+typedef unsigned int u32;
+typedef u64 h160_t[5];
+
+typedef struct blf_t {
+    size_t size;
+    u64 *bits;
+} blf_t;
+
+static cl_program build_program(cl_context ctx, cl_device_id dev){
+    FILE *f=fopen("lib/utils_opencl.cl","r");
+    if(!f){ fprintf(stderr,"Failed to open utils_opencl.cl\n"); return NULL; }
+    fseek(f,0,SEEK_END); long sz=ftell(f); rewind(f);
+    char *src=malloc(sz+1); fread(src,1,sz,f); src[sz]='\0'; fclose(f);
+    const char *sources[]={src};
+    cl_int err; cl_program p=clCreateProgramWithSource(ctx,1,sources,NULL,&err);
+    if(err!=CL_SUCCESS){ free(src); return NULL; }
+    err=clBuildProgram(p,1,&dev,"",NULL,NULL);
+    if(err!=CL_SUCCESS){
+        size_t log_size; clGetProgramBuildInfo(p,dev,CL_PROGRAM_BUILD_LOG,0,NULL,&log_size);
+        char *log=malloc(log_size+1);
+        clGetProgramBuildInfo(p,dev,CL_PROGRAM_BUILD_LOG,log_size,log,NULL);
+        log[log_size]='\0'; fprintf(stderr,"OpenCL build error:\n%s\n",log);
+        free(log); clReleaseProgram(p); p=NULL;
+    }
+    free(src); return p;
+}
+
+static int blf_has_batch(uint8_t *out, blf_t *blf, const h160_t *hashes, size_t count){
+    cl_int err; cl_platform_id platform; cl_device_id device;
+    err=clGetPlatformIDs(1,&platform,NULL); if(err!=CL_SUCCESS) return 0;
+    err=clGetDeviceIDs(platform,CL_DEVICE_TYPE_GPU,1,&device,NULL); if(err!=CL_SUCCESS) return 0;
+    cl_context ctx=clCreateContext(NULL,1,&device,NULL,NULL,&err); if(err!=CL_SUCCESS) return 0;
+    cl_command_queue q=clCreateCommandQueue(ctx,device,0,&err); if(err!=CL_SUCCESS){ clReleaseContext(ctx); return 0; }
+    cl_program prog=build_program(ctx,device); if(!prog){ clReleaseCommandQueue(q); clReleaseContext(ctx); return 0; }
+    cl_kernel kern=clCreateKernel(prog,"blf_has_kernel",&err); if(err!=CL_SUCCESS){ clReleaseProgram(prog); clReleaseCommandQueue(q); clReleaseContext(ctx); return 0; }
+    size_t bits_size=blf->size*sizeof(u64);
+    size_t hash_size=count*5*sizeof(u32);
+    size_t out_size=count*sizeof(uint8_t);
+    cl_mem buf_bits=clCreateBuffer(ctx,CL_MEM_READ_ONLY|CL_MEM_COPY_HOST_PTR,bits_size,blf->bits,&err); if(err!=CL_SUCCESS) goto cleanup;
+    cl_mem buf_hash=clCreateBuffer(ctx,CL_MEM_READ_ONLY|CL_MEM_COPY_HOST_PTR,hash_size,(void*)hashes,&err); if(err!=CL_SUCCESS){ clReleaseMemObject(buf_bits); goto cleanup; }
+    cl_mem buf_out=clCreateBuffer(ctx,CL_MEM_WRITE_ONLY,out_size,NULL,&err); if(err!=CL_SUCCESS){ clReleaseMemObject(buf_bits); clReleaseMemObject(buf_hash); goto cleanup; }
+    cl_ulong size=blf->size;
+    clSetKernelArg(kern,0,sizeof(buf_bits),&buf_bits);
+    clSetKernelArg(kern,1,sizeof(size),&size);
+    clSetKernelArg(kern,2,sizeof(buf_hash),&buf_hash);
+    clSetKernelArg(kern,3,sizeof(buf_out),&buf_out);
+    size_t global=count; err=clEnqueueNDRangeKernel(q,kern,1,NULL,&global,NULL,0,NULL,NULL);
+    if(err!=CL_SUCCESS){ clReleaseMemObject(buf_bits); clReleaseMemObject(buf_hash); clReleaseMemObject(buf_out); goto cleanup; }
+    clFinish(q);
+    err=clEnqueueReadBuffer(q,buf_out,CL_TRUE,0,out_size,out,0,NULL,NULL);
+    clReleaseMemObject(buf_bits); clReleaseMemObject(buf_hash); clReleaseMemObject(buf_out);
+cleanup:
+    clReleaseKernel(kern); clReleaseProgram(prog); clReleaseCommandQueue(q); clReleaseContext(ctx); return err==CL_SUCCESS;
+}
+
+int blf_has_opencl_batch(uint8_t *out, blf_t *blf, const h160_t *hashes, size_t count){
+    return blf_has_batch(out, blf, hashes, count);
+}
+

--- a/lib/utils_opencl.cl
+++ b/lib/utils_opencl.cl
@@ -1,0 +1,32 @@
+#pragma OPENCL EXTENSION cl_khr_int64_base_atomics : enable
+
+__kernel void blf_has_kernel(__global const ulong *bits, ulong size,
+                             __global const uint *hashes,
+                             __global uchar *out){
+    size_t gid=get_global_id(0);
+    __global const uint *h=hashes+gid*5;
+    ulong a1=((ulong)h[0]<<32)|h[1];
+    ulong a2=((ulong)h[2]<<32)|h[3];
+    ulong a3=((ulong)h[4]<<32)|h[0];
+    ulong a4=((ulong)h[1]<<32)|h[2];
+    ulong a5=((ulong)h[3]<<32)|h[4];
+    const uchar shifts[4]={24,28,36,40};
+    int ok=1;
+    for(int i=0;i<4 && ok;i++){
+        uchar S=shifts[i];
+        ulong idx[5]={
+            (a1<<S)|(a2>>S),
+            (a2<<S)|(a3>>S),
+            (a3<<S)|(a4>>S),
+            (a4<<S)|(a5>>S),
+            (a5<<S)|(a1>>S)
+        };
+        for(int j=0;j<5 && ok;j++){
+            ulong pos=idx[j] % (size*64UL);
+            ulong word=pos/64UL;
+            ulong bit=1UL<<(pos & 63UL);
+            ok &= (bits[word] & bit) != 0;
+        }
+    }
+    out[gid]=ok?1:0;
+}

--- a/lib/xoshiro_opencl.c
+++ b/lib/xoshiro_opencl.c
@@ -1,0 +1,53 @@
+#include <CL/cl.h>
+#include <stdint.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+#include "xoshiro256ss.h"
+
+static cl_program build_program(cl_context ctx, cl_device_id dev){
+    FILE *f=fopen("lib/xoshiro_opencl.cl","r");
+    if(!f){ fprintf(stderr,"Failed to open xoshiro_opencl.cl\n"); return NULL; }
+    fseek(f,0,SEEK_END); long size=ftell(f); rewind(f);
+    char *src=malloc(size+1); fread(src,1,size,f); src[size]='\0'; fclose(f);
+    const char *sources[]={src};
+    cl_int err; cl_program p=clCreateProgramWithSource(ctx,1,sources,NULL,&err);
+    if(err!=CL_SUCCESS){ free(src); return NULL; }
+    err=clBuildProgram(p,1,&dev,"",NULL,NULL);
+    if(err!=CL_SUCCESS){
+        size_t log_size; clGetProgramBuildInfo(p,dev,CL_PROGRAM_BUILD_LOG,0,NULL,&log_size);
+        char *log=malloc(log_size+1);
+        clGetProgramBuildInfo(p,dev,CL_PROGRAM_BUILD_LOG,log_size,log,NULL);
+        log[log_size]='\0'; fprintf(stderr,"OpenCL build error:\n%s\n",log);
+        free(log); clReleaseProgram(p); p=NULL;
+    }
+    free(src); return p;
+}
+
+int xoshiro256ss_opencl_filln(struct xoshiro256ss *rng, uint64_t *buf, size_t n){
+    cl_int err; cl_platform_id platform; cl_device_id device;
+    err=clGetPlatformIDs(1,&platform,NULL); if(err!=CL_SUCCESS) return 0;
+    err=clGetDeviceIDs(platform,CL_DEVICE_TYPE_GPU,1,&device,NULL); if(err!=CL_SUCCESS) return 0;
+    cl_context ctx=clCreateContext(NULL,1,&device,NULL,NULL,&err); if(err!=CL_SUCCESS) return 0;
+    cl_command_queue q=clCreateCommandQueue(ctx,device,0,&err); if(err!=CL_SUCCESS){ clReleaseContext(ctx); return 0; }
+    cl_program prog=build_program(ctx,device); if(!prog){ clReleaseCommandQueue(q); clReleaseContext(ctx); return 0; }
+    cl_kernel kern=clCreateKernel(prog,"xoshiro_kernel",&err); if(err!=CL_SUCCESS){ clReleaseProgram(prog); clReleaseCommandQueue(q); clReleaseContext(ctx); return 0; }
+
+    size_t state_size=4*XOSHIRO256SS_WIDTH*sizeof(uint64_t);
+    size_t out_size=n*XOSHIRO256SS_WIDTH*sizeof(uint64_t);
+    cl_mem buf_state=clCreateBuffer(ctx,CL_MEM_READ_WRITE|CL_MEM_COPY_HOST_PTR,state_size,rng->s,&err); if(err!=CL_SUCCESS) goto cleanup;
+    cl_mem buf_out=clCreateBuffer(ctx,CL_MEM_WRITE_ONLY,out_size,NULL,&err); if(err!=CL_SUCCESS){ clReleaseMemObject(buf_state); goto cleanup; }
+
+    clSetKernelArg(kern,0,sizeof(buf_state),&buf_state);
+    cl_uint rounds=(cl_uint)n; clSetKernelArg(kern,1,sizeof(rounds),&rounds);
+    clSetKernelArg(kern,2,sizeof(buf_out),&buf_out);
+    size_t global=XOSHIRO256SS_WIDTH;
+    err=clEnqueueNDRangeKernel(q,kern,1,NULL,&global,NULL,0,NULL,NULL); if(err!=CL_SUCCESS){ clReleaseMemObject(buf_state); clReleaseMemObject(buf_out); goto cleanup; }
+    clFinish(q);
+    err=clEnqueueReadBuffer(q,buf_out,CL_TRUE,0,out_size,buf,0,NULL,NULL);
+    if(err==CL_SUCCESS)
+        clEnqueueReadBuffer(q,buf_state,CL_TRUE,0,state_size,rng->s,0,NULL,NULL);
+    clReleaseMemObject(buf_state); clReleaseMemObject(buf_out);
+cleanup:
+    clReleaseKernel(kern); clReleaseProgram(prog); clReleaseCommandQueue(q); clReleaseContext(ctx); return err==CL_SUCCESS;
+}

--- a/lib/xoshiro_opencl.cl
+++ b/lib/xoshiro_opencl.cl
@@ -1,0 +1,20 @@
+__kernel void xoshiro_kernel(__global ulong *state, uint rounds, __global ulong *out){
+    uint lane = get_global_id(0);
+    __global ulong *s0p = state + lane;
+    __global ulong *s1p = state + lane + 8;
+    __global ulong *s2p = state + lane + 16;
+    __global ulong *s3p = state + lane + 24;
+    ulong s0=*s0p, s1=*s1p, s2=*s2p, s3=*s3p;
+    for(uint i=0;i<rounds;i++){
+        ulong result = rotate(s1*5UL,7)*9UL;
+        ulong t = s1<<17;
+        s2 ^= s0;
+        s3 ^= s1;
+        s1 ^= s2;
+        s0 ^= s3;
+        s2 ^= t;
+        s3 = rotate(s3,45);
+        out[i*8+lane]=result;
+    }
+    *s0p=s0; *s1p=s1; *s2p=s2; *s3p=s3;
+}

--- a/readme.md
+++ b/readme.md
@@ -187,6 +187,17 @@ Here are the steps I followed to run `ecloop` on Windows:
 
 If no errors appear, `ecloop` has been compiled successfully and is ready to use. For example, you can run a benchmark with: `./ecloop bench`.
 
+## Build on Windows with MinGW
+
+Install [MinGW-w64](https://www.mingw-w64.org/) and an OpenCL SDK from your GPU vendor. Then open the MinGW shell and run:
+
+```sh
+git clone https://github.com/vladkens/ecloop.git && cd ecloop
+mingw32-make build CC=x86_64-w64-mingw32-gcc EXE=.exe NASM_FMT=win64
+```
+
+The resulting `ecloop.exe` will run natively on Windows.
+
 ## Performance compare
 
 Tests were done on an Intel N100.

--- a/xoshiro256ss-avx/xoshiro256ss.h
+++ b/xoshiro256ss-avx/xoshiro256ss.h
@@ -42,6 +42,10 @@ xoshiro256ss_filln(struct xoshiro256ss *rng, uint64_t *buf, size_t n);
 void
 xoshiro256ss_filln_f64n(struct xoshiro256ss *rng, double *buf, size_t n);
 
+#ifdef USE_OPENCL
+int xoshiro256ss_opencl_filln(struct xoshiro256ss *rng, uint64_t *buf, size_t n);
+#endif
+
 /*
  * TODO: implement this:
 


### PR DESCRIPTION
## Summary
- compile new xoshiro_opencl module
- implement OpenCL kernel and host helper for xoshiro256** RNG
- expose optional GPU PRNG function in header and utils
- call GPU PRNG when available
- compile with USE_OPENCL and offload ECC mul step in cmd_mul

## Testing
- `make build`


------
https://chatgpt.com/codex/tasks/task_e_6873b86d589083229322b69c783b90e0